### PR TITLE
Fixed CI workflow action pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,42 +16,78 @@ permissions:
 
 jobs:
   lint-and-typecheck:
-    name: Lint & typecheck
+    name: Lint & typecheck (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          node-version: 24
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn lint
       - run: yarn typecheck
 
   unit-tests:
-    name: Unit tests
+    name: Unit tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          node-version: 24
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn test:coverage
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: coverage
+          name: coverage-node-${{ matrix.node-version }}
           path: coverage/
           if-no-files-found: ignore
           retention-days: 7
 
-  build-and-e2e:
-    name: Build & E2E
+  build:
+    name: Build (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
+    env:
+      # Fixture mode keeps PRs off the real GitHub API — no secrets required,
+      # deterministic output, fast. The scheduled smoke.yml workflow exercises
+      # the real-GitHub path separately.
+      NODE_CMS_USE_FIXTURE: '1'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - run: yarn install --frozen-lockfile --ignore-scripts
+      - run: yarn build
+
+  e2e:
+    name: E2E (Node 22)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -60,17 +96,19 @@ jobs:
       # the real-GitHub path separately.
       NODE_CMS_USE_FIXTURE: '1'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          node-version: 24
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
           cache: yarn
       - run: yarn install --frozen-lockfile --ignore-scripts
 
       # Cache Playwright browsers keyed on the lockfile's @playwright/test entry.
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -90,8 +128,18 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [lint-and-typecheck, unit-tests, build, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,8 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: yarn


### PR DESCRIPTION
ref [GVA-801](https://linear.app/ghost/issue/GVA-801)

- Pin GitHub Actions workflow dependencies to full commit SHAs with version comments so org policy allows CI to start.
- Run lint/typecheck, unit coverage, and fixture builds on Node 22 and Node 24 to match the repo's declared `>=22.0.0` support floor plus current `.nvmrc`/CI runtime.
- Run browser E2E once on Node 22, the Netlify/runtime floor, to avoid duplicate Playwright browser installs while still covering the user-facing static-site paths.
- Add a stable `All tests pass` aggregator job for branch protection.

## Why

The latest scheduled smoke workflow failed during job setup because TryGhost policy rejects tag-pinned actions such as `actions/checkout@v6` and `actions/setup-node@v6`. That means the real-GitHub smoke path currently cannot run at all.

This PR fixes that CI setup blocker and adds the stable status check required before the repo ruleset can require one durable check name instead of individual matrix jobs.

## CI trust handoff

`verified_ci_trust: medium`, not high.

Evidence supporting medium:

- PR CI runs lint/typecheck, unit coverage, fixture builds, and Playwright E2E.
- Unit coverage enforces 100% lines/functions/branches for `scripts/**/*.js`.
- E2E covers static-site rendering, project/detail routes, filtering hydration, share-button hydration, and 404 behavior.
- The GitHub/Gist boundary is covered in unit tests with mocked Octokit and in a scheduled/manual smoke workflow against the real API.

High-trust blockers still remaining:

- Coverage thresholds apply to `scripts/**/*.js`, not the active web-app source under `src/`.
- The real GitHub/Gist smoke path is scheduled/manual, not PR-gated because it requires `NODE_CMS_GITHUB_TOKEN`.

After this PR lands, Renovate should still use the safe preset unless a later CI-trust pass adds the remaining high-trust coverage evidence.

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/ci.yml .github/workflows/smoke.yml`
- `rg -n "uses: .*@v[0-9]" .github/workflows` returned no matches
- `yarn lint`
- `ASTRO_TELEMETRY_DISABLED=1 yarn typecheck`
- `yarn test:coverage`
- `ASTRO_TELEMETRY_DISABLED=1 NODE_CMS_USE_FIXTURE=1 yarn build`
- `ASTRO_TELEMETRY_DISABLED=1 NODE_CMS_USE_FIXTURE=1 yarn test:e2e`
