### PR TITLE
Updated Renovate shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["github>netlify/renovate-config"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>TryGhost/renovate-config:safe"]
 }


### PR DESCRIPTION
ref [GVA-801](https://linear.app/ghost/issue/GVA-801)

## Summary

- Standardizes this repo on Ghost's shared safe Renovate preset: `local>TryGhost/renovate-config:safe`.
- Adds the Renovate schema reference to the existing root `renovate.json`.

## Preset decision

The cleanrepos resolver returned `expected_preset: safe` from repo-meta `ci_trust: medium` for `nodecmsguide`. Live verification after #223 confirms the repo now has the stable `All tests pass` gate, but CI-trust remains medium because coverage is currently focused on `scripts/**/*.js` rather than broad source coverage. That makes the safe preset the correct cleanup target.

## Config details

- Previous config location: root `renovate.json`.
- New config location: root `renovate.json`.
- No `package.json` Renovate key was present or removed.
- Dropped override/preset: `github>netlify/renovate-config`, replaced by Ghost's shared safe preset.
- Runtime evidence: `.nvmrc` is `24`, `package.json` declares `engines.node >=22.0.0`, Netlify uses Node `22`, and GitHub Actions use floating major Node `22`/`24` values. There is no exact Node patch pin to protect with local package rules.
- Package-manager evidence: this repo is still on Yarn with no `packageManager` field, so no pnpm compatibility rule is needed in this PR.

## Verification

- `uv run python skills/repo-renovate-config/scripts/resolve_preset.py nodecmsguide`
- Inspected current open Renovate PRs for context.
- `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('OK renovate.json')"`
- `yarn lint`

`renovate-config-validator` was not run locally because it is not installed in this repo or on the PATH.