### PR TITLE
Fixed local build data fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,19 +103,20 @@ Load projects/pages via `getCollection('projects')` / `getEntry('pages', slug)` 
 
 ## Environment Variables
 
-Required for build-time GitHub data fetching:
+Used for build-time GitHub data fetching:
 
-- `NODE_CMS_GITHUB_TOKEN` — GitHub personal access token with permission to create Gists
+- `NODE_CMS_GITHUB_TOKEN` — GitHub personal access token with permission to create Gists. When unset outside production, builds use the checked-in fixture data.
 - `NODE_CMS_USE_FIXTURE` — set to `1` to bypass GitHub entirely and load the checked-in fixture at `test/fixtures/node-cms-archive.json`. Used by CI and the test suite; not for production builds.
 
 For local development, create a `.env` file at the repo root. On Netlify, this is configured in the site's environment settings.
 
 ## Data Fetching
 
-GitHub metrics are fetched at build time by the scripts in `/scripts`:
+GitHub metrics are loaded at build time by the scripts in `/scripts`:
 
+- Local builds without `NODE_CMS_GITHUB_TOKEN` and CI builds with `NODE_CMS_USE_FIXTURE=1` use `test/fixtures/node-cms-archive.json`
 - Raw archive data is cached locally in `/tmp` and remotely in a GitHub Gist
-- If the cache is more than 24 hours old, fresh data is pulled from GitHub
+- Production builds should provide `NODE_CMS_GITHUB_TOKEN`; when it is set and the cache is more than 24 hours old, fresh data is pulled from GitHub
 - `project-data.js` compares newest data with data from ~1 week ago to compute trends
 
 To refresh production data, trigger a new Netlify deploy.
@@ -150,7 +151,7 @@ CI workflows live in `.github/workflows/`:
 Manual verification:
 
 1. `pnpm dev` — verify changes interactively
-2. `NODE_CMS_USE_FIXTURE=1 pnpm build && pnpm preview` — verify the production build without needing a GitHub token
+2. `pnpm build && pnpm preview` — verify the production build locally; without `NODE_CMS_GITHUB_TOKEN`, this uses fixture data
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [nodecms.guide](https://nodecms.guide), a leaderboard of Node.js content management systems.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/ff98559c-c0a7-498d-9989-27f09b139e6f/deploy-status)](https://app.netlify.com/sites/headlesscms/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/ff98559c-c0a7-498d-9989-27f09b139e6f/deploy-status)](https://app.netlify.com/projects/nodecmsguide/deploys)
 
 ## Contributing
 
@@ -24,8 +24,13 @@ pnpm install
 pnpm dev
 ```
 
-In order to successfully retrieve GitHub stars, you will need authentication
-keys for the service.
+Then visit http://localhost:4321/ - Astro will automatically reload when changes occur.
+
+Local builds use the checked-in fixture data unless live GitHub data is
+configured. Production builds should provide live GitHub credentials.
+
+To retrieve live GitHub stars during a build, provide authentication keys for
+the service.
 
 You'll need a personal access token with permission to create Gists. This can be generated at
 <https://github.com/settings/tokens>. When deploying, you must set the environment
@@ -38,9 +43,12 @@ NODE_CMS_GITHUB_TOKEN=examplekey123abc
 
 GitHub data is cached in the `tmp` directory, and online in a Gist. If the data is
 more than 24 hours old, fresh data is fetched from GitHub. Fetching and caching occur
-automatically during the build.
+automatically during builds that use the live data path. CI also forces the
+fixture path explicitly:
 
-Then visit http://localhost:4321/ - Astro will automatically reload when changes occur.
+```bash
+NODE_CMS_USE_FIXTURE=1 pnpm build
+```
 
 To preview a production build locally:
 

--- a/scripts/__tests__/fetch-archive.test.js
+++ b/scripts/__tests__/fetch-archive.test.js
@@ -46,6 +46,8 @@ const {
   removeOutdated,
   updateArchive,
   archiveExpired,
+  getFixtureData,
+  shouldUseFixtureData,
   run,
   default: defaultRun,
 } = fetchArchive;
@@ -67,6 +69,7 @@ beforeEach(() => {
   _resetCacheForTesting();
   _setOctokitForTesting(mockOctokitInstance);
   delete process.env.NODE_CMS_USE_FIXTURE;
+  delete process.env.CONTEXT;
   process.env.NODE_CMS_GITHUB_TOKEN = 'test-token';
   // Silence console output from warn/log.
   vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -444,6 +447,63 @@ describe('run', () => {
     expect(mockOctokitInstance.rest.gists.create).not.toHaveBeenCalled();
     // Fixture mode reads the fixture file path.
     expect(mockFs.readJson.mock.calls[0][0]).toMatch(/test\/fixtures\/node-cms-archive\.json$/);
+  });
+
+  it('uses fixture data by default when no GitHub token is configured', async () => {
+    delete process.env.NODE_CMS_GITHUB_TOKEN;
+    const fixture = {
+      timestamp: 9999,
+      data: { ghost: [{ timestamp: 9999, stars: 1, forks: 1, issues: 1 }] },
+    };
+    mockFs.readJson.mockResolvedValue(fixture);
+
+    const result = await run([]);
+
+    expect(result).toEqual(fixture.data);
+    expect(MockOctokit).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.paginate).not.toHaveBeenCalled();
+    expect(mockOctokitInstance.rest.repos.get).not.toHaveBeenCalled();
+    expect(mockFs.readJson).toHaveBeenCalledOnce();
+    expect(mockFs.readJson.mock.calls[0][0]).toMatch(/test\/fixtures\/node-cms-archive\.json$/);
+  });
+
+  it('getFixtureData returns the fixture payload data', async () => {
+    const fixture = {
+      timestamp: 9999,
+      data: { ghost: [{ timestamp: 9999, stars: 1, forks: 1, issues: 1 }] },
+    };
+    mockFs.readJson.mockResolvedValue(fixture);
+
+    await expect(getFixtureData()).resolves.toEqual(fixture.data);
+  });
+
+  it('does not use fixture data by default in production context', async () => {
+    delete process.env.NODE_CMS_GITHUB_TOKEN;
+    process.env.CONTEXT = 'production';
+    mockFs.readJson.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(run([])).rejects.toThrow(/NODE_CMS_GITHUB_TOKEN/);
+
+    expect(MockOctokit).not.toHaveBeenCalled();
+    expect(mockFs.readJson).toHaveBeenCalledOnce();
+    expect(mockFs.readJson.mock.calls[0][0]).toMatch(/tmp\/node-cms-archive\.json$/);
+  });
+
+  it('shouldUseFixtureData respects fixture, local, token, and production settings', () => {
+    delete process.env.NODE_CMS_USE_FIXTURE;
+    delete process.env.NODE_CMS_GITHUB_TOKEN;
+    delete process.env.CONTEXT;
+    expect(shouldUseFixtureData()).toBe(true);
+
+    process.env.NODE_CMS_GITHUB_TOKEN = 'test-token';
+    expect(shouldUseFixtureData()).toBe(false);
+
+    delete process.env.NODE_CMS_GITHUB_TOKEN;
+    process.env.CONTEXT = 'production';
+    expect(shouldUseFixtureData()).toBe(false);
+
+    process.env.NODE_CMS_USE_FIXTURE = '1';
+    expect(shouldUseFixtureData()).toBe(true);
   });
 
   it('returns the in-memory cache on subsequent calls', async () => {

--- a/scripts/fetch-archive.js
+++ b/scripts/fetch-archive.js
@@ -141,11 +141,25 @@ export function archiveExpired(archive) {
   return differenceInMinutes(Date.now(), archive.timestamp) > 1410;
 }
 
+export async function getFixtureData() {
+  const fixture = await fs.readJson(path.join(process.cwd(), FIXTURE_PATH));
+  return fixture.data;
+}
+
+export function shouldUseFixtureData() {
+  return (
+    process.env.NODE_CMS_USE_FIXTURE === '1' ||
+    (!process.env.NODE_CMS_GITHUB_TOKEN && process.env.CONTEXT !== 'production')
+  );
+}
+
 export async function run(projects) {
-  // Fixture mode short-circuit for CI / tests — never touches Octokit.
-  if (process.env.NODE_CMS_USE_FIXTURE === '1') {
-    const fixture = await fs.readJson(path.join(process.cwd(), FIXTURE_PATH));
-    return fixture.data;
+  // Local/dev builds default to deterministic fixture data unless a token is
+  // configured. CI can also force this path explicitly. Production keeps the
+  // live-data path so missing production credentials do not silently ship stale
+  // fixture metrics.
+  if (shouldUseFixtureData()) {
+    return getFixtureData();
   }
 
   // Return cached data if available (avoids redundant fetches during build)


### PR DESCRIPTION
## Summary

- Default local builds without `NODE_CMS_GITHUB_TOKEN` to the checked-in fixture archive data
- Keep the live GitHub/Gist path for production context and for any build where a token is configured
- Add regression coverage so production context does not silently fall back to fixtures when credentials are missing
- Update README/AGENTS data-fetching docs to describe fixture vs live-data behavior
- Keep the Netlify status badge pointed at the current `nodecmsguide` project path

## Validation

- `env -u NODE_CMS_GITHUB_TOKEN -u NODE_CMS_USE_FIXTURE -u CONTEXT ASTRO_TELEMETRY_DISABLED=1 corepack pnpm@10.34.4 build`
- `corepack pnpm@10.34.4 test:coverage`
- `corepack pnpm@10.34.4 lint`
- `ASTRO_TELEMETRY_DISABLED=1 corepack pnpm@10.34.4 typecheck`
- `ASTRO_TELEMETRY_DISABLED=1 NODE_CMS_USE_FIXTURE=1 corepack pnpm@10.34.4 test:e2e`
- `git diff --check`

ref [GVA-801](https://linear.app/ghost/issue/GVA-801/clean-repo-nodecmsguide)