### PR TITLE
Fixed README Netlify badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [nodecms.guide](https://nodecms.guide), a leaderboard of Node.js content management systems.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/ff98559c-c0a7-498d-9989-27f09b139e6f/deploy-status)](https://app.netlify.com/sites/headlesscms/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/ff98559c-c0a7-498d-9989-27f09b139e6f/deploy-status)](https://app.netlify.com/projects/nodecmsguide/deploys)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Updated the README Netlify deploy-status badge link from the old `headlesscms` site path to the current `nodecmsguide` project path

## Validation

- `git diff --check`
- `corepack pnpm@10.34.4 lint`

ref [GVA-801](https://linear.app/ghost/issue/GVA-801/clean-repo-nodecmsguide)