### PR TITLE
Updated AGENTS Astro version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Project-specific instructions for AI agents working on this codebase.
 
 ## Tech Stack
 
-- **Framework:** [Astro](https://astro.build/) 5.x (static output)
+- **Framework:** [Astro](https://astro.build/) 6.x (static output)
 - **Interactive Components:** React 19 via `@astrojs/react`
 - **Language:** TypeScript (strict, extends `astro/tsconfigs/strict`)
 - **Styling:** Plain CSS (`src/styles/global.css`) + scoped styles in `.astro` components


### PR DESCRIPTION
## Summary

- Updated AGENTS.md to describe the current Astro 6.x stack

## Validation

- `git diff --check`
- `corepack pnpm@10.34.4 lint`

ref [GVA-801](https://linear.app/ghost/issue/GVA-801/clean-repo-nodecmsguide)