### PR TITLE
Updated Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>TryGhost/renovate-config:safe"]
+  "extends": ["local>TryGhost/renovate-config"]
 }


### PR DESCRIPTION
## Summary

- Standardizes nodecmsguide on the default shared TryGhost Renovate preset.
- Updates the existing root `renovate.json` from `local>TryGhost/renovate-config:safe` to `local>TryGhost/renovate-config`.

## Renovate config details

- Shared preset applied: `local>TryGhost/renovate-config`
- Preset decision source: cleanrepos repo-meta via `resolve_preset.py nodecmsguide`
  - `type: web-app`
  - `ci_trust: high`
  - `ci_trust_source: repo-meta`
  - `expected_preset: default`
- Previous config location: root `renovate.json`
- New config location: root `renovate.json`
- `package.json` Renovate key removal: none; no top-level `renovate` key exists.
- Retained overrides: none; the config only contains `$schema` and `extends`.
- Dropped overrides: none.
- Runtime/package-manager/dependency package rules: none added. CI uses `.nvmrc` through `node-version-file`, package.json declares `node >=22.23.1`, and this is not a pinned-runtime repo with an exact `setup-node` patch.
- Open Renovate PRs inspected for context only:
  - #237 Update pnpm to v11
  - #232 Update astro monorepo (major)

## Verification

- Parsed `renovate.json` with Node JSON.parse.
- Confirmed `package.json` has no top-level `renovate` key.
- Ran `corepack pnpm lint`.
- `renovate-config-validator` was not run locally because Renovate is not a repo dependency and this config uses a local TryGhost preset reference resolved in the Renovate app environment.
