### PR TITLE
Renamed CI gate job to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,8 @@ jobs:
           path: playwright-report/
           retention-days: 14
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [lint-and-typecheck, unit-tests, build, e2e]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires the status check named exactly `All tests pass`. Requiring a legacy or per-job check name couples branch protection to the CI matrix: rename the job (or restructure the workflow) and the required check silently stops existing, blocking every PR until someone edits the ruleset.

The org is standardizing every repo on the aggregator-gate convention: one job whose name — and therefore check context — is exactly `Required checks pass`. Rulesets then have a single stable target that never needs to track CI-internal job names.

## What changes

- `ci.yml`: the existing gate job `all-tests-pass` / `All tests pass` becomes `required-checks-pass` / `Required checks pass`. Nothing else changes — same `if: always()`, same single verify step, and identical `needs` coverage (`lint-and-typecheck`, `unit-tests`, `build`, `e2e` — every job in the workflow). Top-level `permissions: contents: read` was already in place.

## Ruleset

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of `All tests pass`, so this PR must go green on the new gate before it can merge.